### PR TITLE
Ignore AM/PM case sensitivity in results

### DIFF
--- a/scraper.go
+++ b/scraper.go
@@ -135,7 +135,7 @@ func ScrapeCapacityRoute(document *goquery.Document) Route {
 				item := strings.TrimSpace(timeAndBoatNameArray[i])
 				item = strings.ReplaceAll(item, "\n", "")
 
-				if strings.Contains(item, "AM") || strings.Contains(item, "PM") {
+                                if strings.Contains(strings.ToLower(item), "am") || strings.Contains(strings.ToLower(item), "pm") {
 					sailing.DepartureTime = item
 				} else if !strings.Contains(item, "Tomorrow") && len(item) > 5 {
 					sailing.VesselName = item


### PR DESCRIPTION
Found an issue where BC Ferries was returning lowercase am/pm but code was expecting uppercase AM/PM.  This patch should handle both.  