### PR TITLE
Check am/pm leading space, dont match ship names.

### DIFF
--- a/scraper.go
+++ b/scraper.go
@@ -135,7 +135,7 @@ func ScrapeCapacityRoute(document *goquery.Document) Route {
 				item := strings.TrimSpace(timeAndBoatNameArray[i])
 				item = strings.ReplaceAll(item, "\n", "")
 
-                                if strings.Contains(strings.ToLower(item), "am") || strings.Contains(strings.ToLower(item), "pm") {
+                                if strings.Contains(strings.ToLower(item), " am") || strings.Contains(strings.ToLower(item), " pm") {
 					sailing.DepartureTime = item
 				} else if !strings.Contains(item, "Tomorrow") && len(item) > 5 {
 					sailing.VesselName = item


### PR DESCRIPTION
One more tweak to that last change - without testing for a leading space on the times, "am" after being tolower'ed would match on "Queen of Coquitlam"

This fixes it up. 